### PR TITLE
Fix clear-old-log-file setting

### DIFF
--- a/PyDSS/pyLogger.py
+++ b/PyDSS/pyLogger.py
@@ -3,11 +3,12 @@ import os
 
 
 def getLogger(name, path, LoggerOptions):
+    log_filename = os.path.join(path, name + '.log')
+
     if LoggerOptions['Clear old log file']:
-        test = os.listdir(os.getcwd())
-        for item in test:
-            if item.endswith(".log"):
-                os.remove(item)
+        if os.path.exists(log_filename):
+            os.remove(item)
+
     formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
 
     logger = logging.getLogger(name)
@@ -19,7 +20,7 @@ def getLogger(name, path, LoggerOptions):
     if LoggerOptions['Log to external file']:
         if not os.path.exists(path):
             os.mkdir(path)
-        handler2 = logging.FileHandler(filename=os.path.join(path, name + '.log'))
+        handler2 = logging.FileHandler(filename=log_filename)
         handler2.setFormatter(formatter)
         logger.addHandler(handler2)
     return logger


### PR DESCRIPTION
This code was causing a runtime exception if mulitple processes were
running PyDSS from the same base directory and tried to delete the same
files.

The code was also deleting non-PyDSS log files.

@ann-sherin FYI