### PR TITLE
add check if dss redirect fails

### DIFF
--- a/PyDSS/pyPostprocessor/PostprocessScripts/AutomatedThermalUpgrade.py
+++ b/PyDSS/pyPostprocessor/PostprocessScripts/AutomatedThermalUpgrade.py
@@ -20,7 +20,7 @@ import scipy.spatial.distance as ssd
 from sklearn.cluster import AgglomerativeClustering
 import matplotlib.image as mpimg
 from PyDSS.pyPostprocessor.PostprocessScripts.postprocess_thermal_upgrades import postprocess_thermal_upgrades
-from PyDSS.utils.utils import iter_elements
+from PyDSS.utils.utils import iter_elements, check_redirect
 plt.rcParams.update({'font.size': 14})
 
 # For an overloaded line if a sensible close enough line code is available then simply change the line code
@@ -219,14 +219,11 @@ class AutomatedThermalUpgrade(AbstractPostprocess):
         self.logger.info("Total time = %s", end - start)
         # # TODO: Test impact of applied settings - can't compile the feeder again in PyDSS
         # self.compile_feeder_initialize()
-        # upgrades_file = os.path.join(self.config["Outputs"], "Thermal_upgrades_pen_{}.dss".format(self.pen_level))
-        # dss.run_command("Redirect {}".format(upgrades_file))
-        # self.dssSolver.Solve()
         dss.run_command("Clear")
         base_dss = os.path.join(project.dss_files_path, self.Settings["Project"]["DSS File"])
-        dss.run_command(f"Redirect {base_dss}")
+        check_redirect(base_dss)
         upgrades_file = os.path.join(self.config["Outputs"], "thermal_upgrades.dss")
-        dss.run_command("Redirect {}".format(upgrades_file))
+        check_redirect(upgrades_file)
         self.dssSolver.Solve()
 
         # save new upgraded objects
@@ -980,7 +977,7 @@ class AutomatedThermalUpgrade(AbstractPostprocess):
             self.logger.debug("expected_file_name", expected_file_name)
             if expected_file_name in self.thermal_upgrades_files:
                 expected_file_path = os.path.join(self.config["Outputs"],expected_file_name)
-                dss.run_command("Redirect {}".format(expected_file_path))
+                check_redirect(expected_file_path)
                 # Also append all upgrades in the previous penetration level to the next level
                 with open(os.path.join(self.config["Outputs"], "Thermal_upgrades_pen_{}.dss".format(prev_pen_level)),"r") as datafile:
                     for line in datafile:

--- a/PyDSS/pyPostprocessor/PostprocessScripts/AutomatedVoltageUpgrade.py
+++ b/PyDSS/pyPostprocessor/PostprocessScripts/AutomatedVoltageUpgrade.py
@@ -14,7 +14,7 @@ import math
 from PyDSS.exceptions import InvalidParameter, OpenDssConvergenceError
 from PyDSS.pyPostprocessor.pyPostprocessAbstract import AbstractPostprocess
 from PyDSS.pyPostprocessor.PostprocessScripts.postprocess_voltage_upgrades import postprocess_voltage_upgrades
-from PyDSS.utils.utils import iter_elements
+from PyDSS.utils.utils import iter_elements, check_redirect
 
 plt.rcParams.update({'font.size': 14})
 
@@ -139,7 +139,7 @@ class AutomatedVoltageUpgrade(AbstractPostprocess):
         if not os.path.exists(thermal_dss_file):
             raise InvalidParameter(f"AutomatedThermalUpgrade did not produce thermal_filename")
         dss = dssInstance
-        dss.run_command("Redirect {}".format(thermal_dss_file))
+        check_redirect(thermal_dss_file)
         self.dssSolver = dssSolver
         self.start = time.time()
 
@@ -505,10 +505,10 @@ class AutomatedVoltageUpgrade(AbstractPostprocess):
         self.logger.info("Checking impact of redirected upgrades file")
         dss.run_command("Clear")
         base_dss = os.path.join(project.dss_files_path, self.Settings["Project"]["DSS File"])
-        dss.run_command(f"Redirect {base_dss}")
-        dss.run_command(f"Redirect {thermal_dss_file}")
+        check_redirect(base_dss)
+        check_redirect(thermal_dss_file)
         upgrades_file = os.path.join(self.config["Outputs"], "voltage_upgrades.dss")
-        dss.run_command("Redirect {}".format(upgrades_file))
+        check_redirect(upgrades_file)
         self.dssSolver.Solve()
 
         self.new_reg_controls = {x["name"]: x for x in iter_elements(dss.RegControls, get_reg_control_info)}

--- a/PyDSS/utils/utils.py
+++ b/PyDSS/utils/utils.py
@@ -20,6 +20,12 @@ MAX_PATH_LENGTH = 255
 logger = logging.getLogger(__name__)
 
 
+def check_redirect(file_name):
+    result = dss.run_command("Redirect {}".format(file_name))
+    if result != '':
+        raise Exception(f'Redirect failed {result}')
+
+
 def _get_module_from_extension(filename, **kwargs):
     ext = os.path.splitext(filename)[1].lower()
     if ext == ".json":

--- a/PyDSS/utils/utils.py
+++ b/PyDSS/utils/utils.py
@@ -21,9 +21,24 @@ logger = logging.getLogger(__name__)
 
 
 def check_redirect(file_name):
-    result = dss.run_command("Redirect {}".format(file_name))
-    if result != '':
-        raise Exception(f'Redirect failed {result}')
+    """Runs redirect command for dss file
+    And checks for exception
+
+    Parameters
+    ----------
+    file_name : str
+        dss file to be redirected
+
+    Raises
+    -------
+    Exception
+        Raised if the command fails
+
+    """
+    logger.debug(f"Redirecting DSS file: {file_name}")
+    result = dss.run_command(f"Redirect {file_name}")
+    if result != "":
+        raise Exception(f"Redirect failed for {file_name}, message: {result}")
 
 
 def _get_module_from_extension(filename, **kwargs):


### PR DESCRIPTION
Currently, DSS redirect command doesn't raise exception if it fails. So, check added to raise exception when dss redirect run fails in upgrades code.