### PR TITLE
Allow postprocessors to report convergence errors

### DIFF
--- a/PyDSS/dssInstance.py
+++ b/PyDSS/dssInstance.py
@@ -49,6 +49,7 @@ class OpenDSS:
         self._Options = params
         self._convergenceErrors = 0
         self._maxConvergenceErrorCount = 0
+        self._maxConvergenceError = 0.0
 
         rootPath = params['Project']['Project Path']
         self._ActiveProject = params['Project']['Active Project']
@@ -239,6 +240,48 @@ class OpenDSS:
         self.session.show()
         return
 
+    def _RunPostProcessors(self, step, postprocessors):
+        for postprocessor in postprocessors:
+            orig_step = step
+            has_converged, error, step = postprocessor.run(step, Steps)
+            assert step <= orig_step, "step cannot increment in postprocessor"
+            if not has_converged:
+                name = postprocessor.__class__.__name__
+                self._Logger.warn("postprocessor %s reported a convergence error at step %s", name, step)
+                self._handleConvergenceErrorChecks(step, error)
+
+        return step, has_converged
+
+    def _RunUpdateControllers(self, step):
+        time_step_has_converged = True
+        for priority in range(CONTROLLER_PRIORITIES):
+            priority_has_converged = False
+            for i in range(self._Options["Project"]["Max Control Iterations"]):
+                has_converged, error = self._UpdateControllers(priority, step, UpdateResults=False)
+                if has_converged:
+                    priority_has_converged = True
+                    break
+                else:
+                    self._Logger.debug("Control Loop {} convergence error: {}".format(priority, error))
+                    self._dssSolver.reSolve()
+            if not priority_has_converged:
+                time_step_has_converged = False
+                self._Logger.warning("Control Loop %s no convergence @ %s error=%s", priority, step, error)
+                self._handleConvergenceErrorChecks(step, error)
+
+        return time_step_has_converged
+
+    def _handleConvergenceErrorChecks(self, step, error):
+        self._convergenceErrors += 1
+
+        if self._maxConvergenceError != 0.0 and error > self._maxConvergenceError:
+            self._Logger.error("Convergence error %s exceeded max value %s at step %s", error, self._maxConvergenceError, step)
+            raise PyDssConvergenceMaxError(f"Exceeded max convergence error {error}")
+
+        if self._maxConvergenceErrorCount != 0 and self._convergenceErrors > self._maxConvergenceErrorCount:
+            self._Logger.error("Exceeded convergence error count threshold at step %s", step)
+            raise PyDssConvergenceErrorCountExceeded(f"{self._convergenceErrors} errors occurred")
+
     def _UpdateControllers(self, Priority, Time, UpdateResults):
         maxError = 0.0
 
@@ -311,38 +354,10 @@ class OpenDSS:
 
 
         # run simulation time step and get results
-        time_step_has_converged = True
-        convergence_max_error = self._Options['Project']['Max error tolerance']
-        max_count = self._Options['Project']['Convergence error percent threshold']
+        has_converged = True
         if not self._Options['Project']['Disable PyDSS controllers']:
-            for priority in range(CONTROLLER_PRIORITIES):
-                has_converged = False
-                for i in range(self._Options['Project']['Max Control Iterations']):
-                    _has_converged, error = self._UpdateControllers(priority, step, UpdateResults=False)
-                    if _has_converged:
-                        has_converged = True
-                        break
-                    else:
-                        self._Logger.debug('Control Loop {} convergence error: {}'.format(priority, error))
-                        self._dssSolver.reSolve()
-                if not has_converged:
-                    self._convergenceErrors += 1
-                    time_step_has_converged = False
-                    self._Logger.warning('Control Loop %s no convergence @ %s error=%s', priority, step, error)
-                    if convergence_max_error != 0.0 and error > convergence_max_error:
-                        self._Logger.error("Convergence error %s exceeded max value %s", error, convergence_max_error)
-                        raise PyDssConvergenceMaxError(f"Exceeded max convergence error {error}")
-                    if max_count != 0 and self._convergenceErrors > max_count:
-                        self._Logger.error('Exceeded convergence error count threshold')
-                        raise PyDssConvergenceErrorCountExceeded(f"{self._convergenceErrors} errors occurred")
-
+            has_converged = self._RunUpdateControllers(step)
             self._UpdatePlots()
-            if self._Options['Exports']['Log Results']:
-                if not time_step_has_converged and self._Options['Project']['Skip export on convergence error']:
-                    store_nan = True
-                else:
-                    store_nan = False
-                self.ResultContainer.UpdateResults(store_nan=store_nan)
 
         if self._Options['Frequency']['Enable frequency sweep'] and \
                 self._Options['Project']['Simulation Type'].lower() != 'dynamic':
@@ -365,8 +380,7 @@ class OpenDSS:
             self._increment_flag, helics_time = self._HI.request_time_increment()
 
         self._dssSolver.IncrementTimeStep()
-        if self.ResultContainer:
-            return self.ResultContainer.CurrentResults
+        return has_converged
 
     def DryRunSimulation(self, project, scenario):
         """Run one time point for getting estimated space."""
@@ -379,6 +393,7 @@ class OpenDSS:
 
         try:
             self.RunStep(0)
+            self._ProcessStepResults(0, True, [])
         finally:
             self.ResultContainer.Close()
 
@@ -388,6 +403,7 @@ class OpenDSS:
         startTime = time.time()
         Steps, sTime, eTime = self._dssSolver.SimulationSteps()
         self._maxConvergenceErrorCount = round(self._Options['Project']['Convergence error percent threshold'] * .01 * Steps)
+        self._maxConvergenceError = self._Options['Project']['Max error tolerance']
         self._Logger.info('Running simulation from {} till {}.'.format(sTime, eTime))
         self._Logger.info('Simulation time step {}.'.format(Steps))
         self._Logger.info('Max convergence error count {}.'.format(self._maxConvergenceErrorCount))
@@ -413,17 +429,10 @@ class OpenDSS:
         try:
             step = 0
             while step < Steps:
-                self.RunStep(step)
-
-                if step == 0 and self.ResultContainer is not None:
-                    size = make_human_readable_size(self.ResultContainer.max_num_bytes())
-                    self._Logger.info('Storage requirement estimation: %s, estimated based on first time step run.', size)
-
-                for postprocessor in postprocessors:
-                    step = postprocessor.run(step, Steps)
+                has_converged = self.RunStep(step)
+                step = self._ProcessStepResults(step, has_converged, postprocessors)
                 if self._increment_flag:
-                    step+=1
-
+                    step += 1
         finally:
             if self._Options and self._Options['Exports']['Log Results']:
                 # This is here to guarantee that DatasetBuffers aren't left
@@ -437,6 +446,25 @@ class OpenDSS:
 
         self._Logger.info('Simulation completed in ' + str(time.time() - startTime) + ' seconds')
         self._Logger.info('End of simulation')
+
+    def _ProcessStepResults(self, step, has_converged, postprocessors):
+        if self.ResultContainer is not None and step == 0:
+            size = make_human_readable_size(self.ResultContainer.max_num_bytes())
+            self._Logger.info('Storage requirement estimation: %s, estimated based on first time step run.', size)
+
+        if postprocessors:
+            step, converged = self._RunPostProcessors(step)
+            if not converged:
+                has_converged = False
+
+        if self._Options['Exports']['Log Results']:
+            if not has_converged and self._Options['Project']['Skip export on convergence error']:
+                store_nan = True
+            else:
+                store_nan = False
+            self.ResultContainer.UpdateResults(store_nan=store_nan)
+
+        return step
 
     def RunMCsimulation(self, project, scenario, samples):
         from PyDSS.Extensions.MonteCarlo import MonteCarloSim

--- a/PyDSS/reports/voltage_metrics.py
+++ b/PyDSS/reports/voltage_metrics.py
@@ -25,26 +25,31 @@ class VoltageMetrics(ReportBase):
     The report generates the output file Reports/voltage_metrics.json.
     Metrics 1, 2, 5, and 6 are included within that file.
 
-    Metric 3 must be read from the raw data as in this example.
+    Metric 3 must be read from the raw data as in the example below.
+    Metric 4 must be read from the dataframe-as-binary-file.
 
-    ..code-block:: python
+    This example assumes that data is stored on a per-time-point basis.
 
-        from PyDSS.
+    .. code-block:: python
 
-    The report generates a pandas.DataFrame for metric 4 for each scenario and
-    then serializes that DataFrame to disk as either a CSV file or HDF5
-    depending on the 'Export Format' simulation setting. Those filenames are
-    stored within Reports/voltage_metrics.json. Here is one way to read the
-    data back into a DataFrame.
-
-    ..code-block:: python
-
-        from PyDSS.utils.utils import load_data
         from PyDSS.utils.dataframe_utils import read_dataframe
+        from PyDSS.pydss_results import PyDssResults
 
-        metrics = load_data("Reports/voltage_metrics.json")
-        filenames = metrics["metric_4"]
+        results = PyDssResults("path_to_project")
+        control_mode_scenario = results.scenarios[1]
+
+        # Read metrics 1, 2, 5, and 6 directly from JSON.
+        voltage_metrics = results.read_report("Voltage Metrics")
+        metric_4_filenames = voltage_metrics["metric_4"]
         dfs = [read_dataframe(x) for x in filenames]
+
+        # Read all metric 3 dataframes from raw data into memory in one call.
+        dfs = control_mode_scenario.get_filtered_dataframes("Nodes", "VoltageMetric")
+
+        # Read metric 3 dataframes into memory one at a time.
+        for node_name in control_mode_scenario.list_element_names("Nodes", "VoltageMetric"):
+            df = control_mode_scenario.get_dataframe("Nodes", "VoltageMetric", node_name)
+            # If necessary, convert to a moving average with pandas.
 
     """
     DEFAULTS = {


### PR DESCRIPTION
This PR refactors the RunSimulation code in dssInstance.py to allow postprocessors to report convergence problems. The ResultContainer can be configured to not update data if a postprocessor reports a convergence error.

The return of RunStep is now different. I have not updated documentation and other uses of this method. I'll do that if you guys agree with this implementation.

I have not tested the postprocessor paths; there are no unit tests. I would prefer to test this with Kwami's LiFo code before merging to the main report-metrics branch.