### PR TITLE
Provide option to reduce data store for thermal and voltage reports

### DIFF
--- a/PyDSS/metrics.py
+++ b/PyDSS/metrics.py
@@ -548,7 +548,7 @@ class NodeVoltageMetric(MetricBase):
             timedelta(minutes=inputs["window_size_minutes"]) / sim_resolution
         )
         self._voltage_metrics = NodeVoltageMetrics(
-            prop, start_time, sim_resolution, window_size
+            prop, start_time, sim_resolution, window_size, inputs["store_per_element_data"]
         )
         self._primary_node_names = []
         self._primary_indices = []
@@ -955,6 +955,7 @@ class OverloadsMetricInMemory(OpenDssExportMetric):
             line_loading_percent_moving_average_threshold=inputs["line_loading_percent_moving_average_threshold"],
             transformer_loading_percent_threshold=inputs["transformer_loading_percent_threshold"],
             transformer_loading_percent_moving_average_threshold=inputs["transformer_loading_percent_moving_average_threshold"],
+            store_per_element_data=inputs["store_per_element_data"],
         )
 
     def _append_values(self, time_step, store_nan=False):

--- a/PyDSS/node_voltage_metrics.py
+++ b/PyDSS/node_voltage_metrics.py
@@ -309,7 +309,7 @@ class NodeVoltageMetricsByType:
             total_simulation_duration=num_time_points * resolution,
         )
 
-    def generate(self):
+    def generate(self, store_per_element_data):
         if self._num_time_points == 0:
             logger.error("Cannot generate report with no time points")
             return
@@ -366,6 +366,14 @@ class NodeVoltageMetricsByType:
                 moving_window_minutes,
             )
         )
+
+        if not store_per_element_data:
+            metrics.metric_1.time_points.clear()
+            metrics.metric_2.clear()
+            metrics.metric_3.time_points.clear()
+            metrics.metric_4.percent_node_ansi_a_violations.clear()
+            metrics.metric_5.min_voltages.clear()
+            metrics.metric_5.max_voltages.clear()
 
         return metrics
 
@@ -442,7 +450,7 @@ class NodeVoltageMetrics:
 
     FILENAME = "voltage_metrics.json"
 
-    def __init__(self, prop, start_time, resolution, window_size):
+    def __init__(self, prop, start_time, resolution, window_size, store_per_element_data):
         self._start_time = start_time
         self._resolution = resolution
         self._window_size = window_size
@@ -451,6 +459,7 @@ class NodeVoltageMetrics:
             "primary": NodeVoltageMetricsByType(prop, start_time, resolution, window_size),
             "secondary": NodeVoltageMetricsByType(prop, start_time, resolution, window_size),
         }
+        self._store_per_element_data = store_per_element_data
 
     def generate_report(self, path):
         """Create a summary file containing all metrics.
@@ -470,8 +479,8 @@ class NodeVoltageMetrics:
             return
 
         metrics = VoltageMetricsByBusTypeModel(
-            primaries=self._metrics["primary"].generate(),
-            secondaries=self._metrics["secondary"].generate(),
+            primaries=self._metrics["primary"].generate(self._store_per_element_data),
+            secondaries=self._metrics["secondary"].generate(self._store_per_element_data),
         )
 
         filename = Path(path) / self.FILENAME

--- a/PyDSS/reports/thermal_metrics.py
+++ b/PyDSS/reports/thermal_metrics.py
@@ -35,6 +35,7 @@ class ThermalMetrics(ReportBase):
         "transformer_window_size_hours": 2,
         "transformer_loading_percent_moving_average_threshold": 120,
         "store_all_time_points": False,
+        "store_per_element_data": True,
     }
     FILENAME = "thermal_metrics.json"
     NAME = "Thermal Metrics"
@@ -45,6 +46,7 @@ class ThermalMetrics(ReportBase):
         self._num_lines = 0
         self._num_transformers = 0
         self._resolution = self._get_simulation_resolution()
+        self._files_to_delete = []
 
     def generate(self, output_dir):
         inputs = ThermalMetrics.get_inputs_from_defaults(self._simulation_config, self.NAME)
@@ -60,6 +62,8 @@ class ThermalMetrics(ReportBase):
             f_out.write("\n")
 
         logger.info("Generated %s", filename)
+        for filename in self._files_to_delete:
+            os.remove(filename)
 
     def _generate_from_in_memory_metrics(self):
         scenarios = {}
@@ -72,6 +76,8 @@ class ThermalMetrics(ReportBase):
                 self.FILENAME,
             )
             scenarios[scenario.name] = ThermalMetricsSummaryModel(**load_data(filename))
+            # We won't need this file after we write the consolidated file.
+            self._files_to_delete.append(filename)
 
         return scenarios
 

--- a/PyDSS/thermal_metrics.py
+++ b/PyDSS/thermal_metrics.py
@@ -183,6 +183,7 @@ class ThermalMetrics:
         line_loading_percent_moving_average_threshold,
         transformer_loading_percent_threshold,
         transformer_loading_percent_moving_average_threshold,
+        store_per_element_data,
     ):
         self._prop = prop
         self._start_time = start_time
@@ -208,6 +209,7 @@ class ThermalMetrics:
         self._num_time_points = 0
         self._line_names = None
         self._transformer_names = None
+        self._store_per_element_data = store_per_element_data
 
     def generate_report(self, path):
         """Create a summary file containing all metrics.
@@ -262,6 +264,12 @@ class ThermalMetrics:
             instantaneous_threshold=self._transformer_loading_percent_threshold,
             moving_average_threshold=self._transformer_loading_percent_mavg_threshold,
         )
+
+        if not self._store_per_element_data:
+            line_metric.max_instantaneous_loadings_pct.clear()
+            line_metric.max_moving_average_loadings_pct.clear()
+            transformer_metric.max_instantaneous_loadings_pct.clear()
+            transformer_metric.max_moving_average_loadings_pct.clear()
 
         summary = ThermalMetricsSummaryModel(
             line_loadings=line_metric,

--- a/tests/data/pv_reports_project/simulation.toml
+++ b/tests/data/pv_reports_project/simulation.toml
@@ -132,6 +132,7 @@ transformer_loading_percent_moving_average_threshold = 60
 line_window_size_hours = 1
 line_loading_percent_threshold = 107
 line_loading_percent_moving_average_threshold = 100
+store_per_element_data = true
 
 [[Reports.Types]]
 name = "Voltage Metrics"
@@ -139,3 +140,4 @@ enabled = true
 window_size_minutes = 60
 range_a_limits = [1.025, 1.05]
 range_b_limits = [1.020, 1.054]
+store_per_element_data = true


### PR DESCRIPTION
When we ran snapshot simulations for all of SFO these reports generated far too much data that we usually do not consume. Our default behavior in disco will be to disable this collection. Please note the metrics that will be excluded and indicate whether you are OK with it.