### PR TITLE
Handle case where no transformers are present

### DIFF
--- a/PyDSS/ResultData.py
+++ b/PyDSS/ResultData.py
@@ -120,6 +120,10 @@ class ResultData:
                 if prop.opendss_classes:
                     dss_objs = []
                     for cls in prop.opendss_classes:
+                        if cls not in self._objects_by_class:
+                            logger.warning("Export class=%s is not present in the circuit", cls)
+                            continue
+
                         for obj in self._objects_by_class[cls].values():
                             if obj.Enabled and prop.should_store_name(obj.FullName):
                                 dss_objs.append(obj)

--- a/PyDSS/node_voltage_metrics.py
+++ b/PyDSS/node_voltage_metrics.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from pydantic import BaseModel, Field
 
@@ -177,7 +177,7 @@ class VoltageMetricsModel(VoltageMetricsBaseModel):
         title="metric_6",
         description="metric 6",
     )
-    summary: VoltageMetricsSummaryModel = Field(
+    summary: Union[VoltageMetricsSummaryModel, None] = Field(
         title="summary",
         description="summary of metrics",
     )
@@ -269,6 +269,10 @@ class NodeVoltageMetricsByType:
     def create_summary(metric_1, metric_2, metric_3, metric_5, metric_6, node_names,
                        num_time_points, resolution, range_a_limits, range_b_limits,
                        moving_window_minutes):
+        if not node_names:
+            # There may not be any secondary nodes.
+            return None
+
         max_pnvdoaa = max((x.duration for x in metric_2.values())).total_seconds()
         vdbaab = metric_1.duration.total_seconds()
         mmavdoa = metric_3.duration.total_seconds()

--- a/PyDSS/reports/voltage_metrics.py
+++ b/PyDSS/reports/voltage_metrics.py
@@ -232,7 +232,7 @@ class VoltageMetrics(ReportBase):
             metric_5=vmetric_5,
             metric_6=vmetric_6,
             summary=NodeVoltageMetricsByType.create_summary(
-                vmetric_1, vmetric_2, vmetric_3, vmetric_5, vmetric_6, df.columns,
+                vmetric_1, vmetric_2, vmetric_3, vmetric_5, vmetric_6, list(df.columns),
                 len(df), self._resolution, self._range_a_limits, self._range_b_limits,
                 self._moving_window_minutes
             )


### PR DESCRIPTION
If a user requested the ThermalMetrics report but no transformers were
in the circuit, the simulation failed with an unhandled exception.