### PR TITLE
Add option to export properties aggregated by element group

### DIFF
--- a/PyDSS/ResultData.py
+++ b/PyDSS/ResultData.py
@@ -33,7 +33,11 @@ from PyDSS.utils.simulation_utils import (
 )
 from PyDSS.utils.timing_utils import Timer
 from PyDSS.value_storage import ValueContainer, ValueByNumber
-from PyDSS.metrics import OpenDssPropertyMetric, SummedElementsOpenDssPropertyMetric
+from PyDSS.metrics import (
+    OpenDssPropertyMetric,
+    SummedElementsByGroupOpenDssPropertyMetric,
+    SummedElementsOpenDssPropertyMetric,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -143,7 +147,11 @@ class ResultData:
         if prop.sum_elements:
             metric = self._summed_element_metrics.get(key)
             if metric is None:
-                metric = SummedElementsOpenDssPropertyMetric(prop, dss_objs, self._settings)
+                if prop.sum_groups:
+                    cls = SummedElementsByGroupOpenDssPropertyMetric
+                else:
+                    cls = SummedElementsOpenDssPropertyMetric
+                metric = cls(prop, dss_objs, self._settings)
                 self._summed_element_metrics[key] = metric
             else:
                 metric.add_dss_obj(obj)

--- a/PyDSS/metrics.py
+++ b/PyDSS/metrics.py
@@ -534,11 +534,12 @@ class SummedElementsByGroupOpenDssPropertyMetric(MetricBase):
     """
     def __init__(self, prop, dss_objs, settings):
         super().__init__(prop, dss_objs, settings)
-        self._containers = {x: None for x in prop.sum_groups}
+        self._containers = {}
         self._name_to_group = {}
-        for group, element_names in prop.sum_groups.items():
-            for element_name in element_names:
-                self._name_to_group[element_name] = group
+        for group in prop.sum_groups:
+            self._containers[group["name"]] = None
+            for element_name in group["elements"]:
+                self._name_to_group[element_name] = group["name"]
         self._data_conversion = prop.data_conversion
 
     def _get_value(self, obj):

--- a/docs/source/hdf-data-format.rst
+++ b/docs/source/hdf-data-format.rst
@@ -30,6 +30,11 @@ in an HDF dataset ::
 
     Exports/<scenario-name>/<element-class>/SummedElementProperties/<property-name>
 
+Data stored for an element property across elements of a given type split by
+element name are stored in an HDF dataset ::
+
+    Exports/<scenario-name>/<element-class>/SummedElementProperties/<property-name>__<group>
+
 If a property is configured to compute a moving average, sum, min, or max on
 the data then a suffix is added to the property name.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -49,10 +49,6 @@ set in each scenario's ``Exports.toml`` on a per-property basis.
 - Set ``name_regexes = ["foo.*", "bar\\d+"]`` to only export data for elements
   with names that match one of the listed Python regular expressions. Note
   that backslashes must be escaped.
-- Set ``sum_groups = {group1 = ["elem1", "elem2"], group2 = ["elem3", "elem4"]}``
-  to export sums of a value aggregated by element name. Set ``store_values_type``
-  to ``all`` to collect group values at every time point. Set it to ``sum``
-  to collect a running sum for each group.
 - Set ``limits = [min, max]`` to pre-filter values that are inside or outside
   this range. ``min`` and ``max`` must be the same type. Refer to
   ``limits_filter``.
@@ -75,6 +71,34 @@ set in each scenario's ``Exports.toml`` on a per-property basis.
   ``limits`` field can be applied to these values. Refer to
   ``CUSTOM_FUNCTIONS`` in ``PyDSS/export_list_reader.py`` to see the options
   available.
+- Set ``sum_group_file = file_path`` where file_path is a JSON or TOML file
+  relative to the directory from which you will run PyDSS. The contents of the
+  file should look like this example::
+
+    {
+      "sum_groups": [
+        {
+          "name": "group1",
+          "elements": [
+            "element1",
+            "element2"
+          ]
+        },
+        {
+          "name": "group2",
+          "elements": [
+            "element3",
+            "element4"
+          ]
+        }
+      ]
+    }
+
+  This will export sums of a value aggregated by element name.
+  Set ``store_values_type`` to ``all`` to collect group values at every time
+  point. Set it to ``sum`` to collect a running sum for each group.
+- Alternate to ``sum_groups_file``: Set ``sum_groups`` to the contents of the
+  example above.
 
 
 Run a project

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -49,6 +49,10 @@ set in each scenario's ``Exports.toml`` on a per-property basis.
 - Set ``name_regexes = ["foo.*", "bar\\d+"]`` to only export data for elements
   with names that match one of the listed Python regular expressions. Note
   that backslashes must be escaped.
+- Set ``sum_groups = {group1 = ["elem1", "elem2"], group2 = ["elem3", "elem4"]}``
+  to export sums of a value aggregated by element name. Set ``store_values_type``
+  to ``all`` to collect group values at every time point. Set it to ``sum``
+  to collect a running sum for each group.
 - Set ``limits = [min, max]`` to pre-filter values that are inside or outside
   this range. ``min`` and ``max`` must be the same type. Refer to
   ``limits_filter``.

--- a/tests/test_custom_exports.py
+++ b/tests/test_custom_exports.py
@@ -181,10 +181,16 @@ def test_pv_powers_by_customer_type(cleanup_project):
         "PVSystems": {
             "Powers": {
                 "store_values_type": "all",
-                "sum_groups": {
-                    "com": list(com_pv_systems),
-                    "res": list(res_pv_systems),
-                },
+                "sum_groups": [
+                    {
+                        "name": "com",
+                        "elements": list(com_pv_systems),
+                    },
+                    {
+                        "name": "res",
+                        "elements": list(res_pv_systems),
+                    }
+                ],
             },
         }
     }
@@ -199,10 +205,16 @@ def test_pv_powers_by_customer_type(cleanup_project):
         "PVSystems": {
             "Powers": {
                 "store_values_type": "sum",
-                "sum_groups": {
-                    "com": list(com_pv_systems),
-                    "res": list(res_pv_systems),
-                },
+                "sum_groups": [
+                    {
+                        "name": "com",
+                        "elements": list(com_pv_systems),
+                    },
+                    {
+                        "name": "res",
+                        "elements": list(res_pv_systems),
+                    }
+                ],
             },
         }
     }


### PR DESCRIPTION
This PR satisfies a feature request made by the DISCO team. They want to collect PVSystem power outputs at every time point for a large number of simulations. They don't need the values for every PVSystem. They want the values aggregated by customer type in order to save storage space. Customer type is obviously not a property of an OpenDSS or PyDSS element.

Here is what the team plans to do:
- DISCO will analyze the OpenDSS circuit to determine which load shares a bus with each PVSystem. The load shape profile for each load encodes the customer type in its name (at least for SMART-DS datasets). Record a mapping of PVSystem to customer type.
- DISCO will assign the `sum_groups` field of an export property as defined in this PR.
- PyDSS will collect aggregated values by customer type.
- DISCO will read the values after the simulation.

Here is an example of what the Exports.toml file would look like:
```
[[PVSystems]]
property = "Powers"
store_values_type = "all"

[PVSystems.sum_groups]
com = [ "pvgnem_mpx000635970", "pvgnem_mpx000460267",]
res = [ "pvgnem_mpx000594341", "pvgui_mpx000637601", "pvgui_mpx000460267",]
```