### PR TITLE
Fix loads exports

### DIFF
--- a/PyDSS/dssInstance.py
+++ b/PyDSS/dssInstance.py
@@ -91,7 +91,11 @@ class OpenDSS:
         self._Logger.info('An instance of OpenDSS version ' + self._dssInstance.__version__ + ' has been created.')
 
         for key, path in self._dssPath.items():
-            assert (os.path.exists(path)), '{} path: {} does not exist!'.format(key, path)
+            if path.name == "pyControllerList" and not path.exists():
+                # This will happen if a zipped project with no controllers is unzipped and then run.
+                path.mkdir()
+            else:
+                assert path.exists(), '{} path: {} does not exist!'.format(key, path)
 
         self._CompileModel()
 

--- a/PyDSS/metrics.py
+++ b/PyDSS/metrics.py
@@ -963,6 +963,7 @@ class ExportLoadingsMetric(OpenDssExportMetric):
         return fields[0].strip()
 
     def parse_file(self, filename):
+        count = 0
         with open(filename) as f_in:
             # Skip the header.
             next(f_in)
@@ -973,8 +974,11 @@ class ExportLoadingsMetric(OpenDssExportMetric):
                     index = self._names[name]
                     val = float(fields[2].strip())
                     self._values[index].set_value_from_raw(val)
+                    count += 1
                 else:
-                    assert False, line
+                    # There may be other element types that are not being tracked.
+                    continue
+        assert count == len(self._names), f"count={count} num_names={len(self._names)}"
 
     @staticmethod
     def requires_upper_case():


### PR DESCRIPTION
This fixes an assert that was tripping when the user configured exporting of `CktElement.ExportLoadingsMetric` for only Lines and Transformers, but Capacitors were also present. The code needs to skip the capacitors.