### PR TITLE
Fix data export bug when devices are disabled during a simulation

### DIFF
--- a/PyDSS/dssInstance.py
+++ b/PyDSS/dssInstance.py
@@ -178,6 +178,7 @@ class OpenDSS:
         if reply != "":
             raise OpenDssModelError(f"Error compiling OpenDSS model: {reply}")
 
+    # TODO: This method is broken. Can it be deleted?
     def _ReadControllerDefinitions(self):
         controllers = None
         mappings = os.path.join(os.path.dirname(self._dssPath['pyControllers']), "ControllerMappings")

--- a/PyDSS/utils/dss_utils.py
+++ b/PyDSS/utils/dss_utils.py
@@ -185,7 +185,7 @@ def iter_elements(element_class, element_func):
         print(reg_control["name"])
 
     """
-    element_class.First()
-    for _ in range(element_class.Count()):
+    flag = element_class.First()
+    while flag > 0:
         yield element_func()
-        element_class.Next()
+        flag = element_class.Next()

--- a/tests/common.py
+++ b/tests/common.py
@@ -38,7 +38,7 @@ class FakeElement:
     """Fake that behaves like an OpenDSS element"""
     def __init__(self, full_name, name):
         self.FullName = full_name
-        self.Name = NameError
+        self.Name = name
         self._Class = dss.PVsystems
 
 

--- a/tests/test_custom_exports.py
+++ b/tests/test_custom_exports.py
@@ -161,7 +161,7 @@ def test_pv_powers_by_customer_type(cleanup_project):
     com_sum1 = df[com_cols].sum().sum()
     res_sum1 = df[res_cols].sum().sum()
     total_sum1 = df.sum().sum()
-    assert total_sum1 == com_sum1 + res_sum1
+    assert math.isclose(total_sum1, com_sum1 + res_sum1)
 
     # Collect a running sum for all PVSystem power output.
     data = {


### PR DESCRIPTION
The OpenDSS element iteration process in the data export code was not
correctly handling the case when devices were disabled in the middle of
a simulation. OpenDSS does not return disabled devices and so the code
was exporting the values for the last enabled device multiple times.
That could have resulted in invalid data (worst case) or crashes
(best case) if the dimensional size of the data was different across
enabled and disabled elements.