### PR TITLE
Move aiohttp package to extras installation

### DIFF
--- a/PyDSS/reports/voltage_metrics.py
+++ b/PyDSS/reports/voltage_metrics.py
@@ -163,7 +163,7 @@ class VoltageMetrics(ReportBase):
         num_time_points_violate_range_b = 0
         for timestamp, row in df.iterrows():
             num_range_a_violations = 0
-            for name, val in row.iteritems():
+            for name, val in row.items():
                 if val > self._range_a_limits.max or val < self._range_a_limits.min:
                     metric_2[name] += 1
                     num_range_a_violations += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 bokeh
 networkx
 toml
-OpenDSSDirect.py>=0.6.0
+OpenDSSDirect.py~=0.7.0
 Shapely
 click
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ tables
 h5py
 helics
 terminaltables
-aiohttp
-aiohttp_swagger3==0.4.3
 requests
 pymongo
 pydantic>=1.8

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,11 @@ dev_requires = [
     "sphinx-rtd-theme",
 ]
 
+http_server_requires = [
+    "aiohttp",
+    "aiohttp_swagger3==0.4.3",
+]
+
 setup(name='dsspy',
     version=find_version("PyDSS", "__init__.py"),
     description='A high-level python interface for OpenDSS',
@@ -80,6 +85,7 @@ setup(name='dsspy',
         "License :: OSI Approved :: BSD License",
     ],
     extras_require={
-        "dev": dev_requires,
-    }
+            "dev": dev_requires,
+            "http_server": http_server_requires,
+        }
     )


### PR DESCRIPTION
Inclusion of this package in the default installation sometimes causes Windows users to experience failures. aiohttp requires the package multidict, which at least sometimes has to built from source. If the Windows user does not already have the correct version of Microsoft C++ Build Tools installed, the process will fail. The user then has to install those tools, which involves downloading a 9 GB package. This is onerous and not usually necessary because most PyDSS users do not need the aiohttp package.