### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
           #os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]
+        python-version: ["3.7", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/PyDSS/__init__.py
+++ b/PyDSS/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.6"
+__version__ = "2.2.7"
 
 from PyDSS.utils.timing_utils import timer_stats_collector
 from . import *

--- a/PyDSS/modes/Dynamic.py
+++ b/PyDSS/modes/Dynamic.py
@@ -3,7 +3,6 @@ import math
 
 from PyDSS.modes.solver_base import solver_base
 from PyDSS.simulation_input_models import ProjectModel
-from PyDSS.utils.timing_utils import timer_stats_collector, track_timing
 
 
 class Dynamic(solver_base):
@@ -41,7 +40,6 @@ class Dynamic(solver_base):
         self._dssSolution.MaxControlIterations(self._settings.project.max_control_iterations)
         return
 
-    @track_timing(timer_stats_collector)
     def SolveFor(self, mStartTime, mTimeStep):
         Hour = int(mStartTime/60)
         Min = mStartTime % 60
@@ -50,7 +48,6 @@ class Dynamic(solver_base):
         self._dssSolution.Solve()
         return self._dssSolution.Converged()
 
-    @track_timing(timer_stats_collector)
     def IncStep(self):
         self._dssSolution.StepSize(self._sStepRes)
         self._dssSolution.Solve()
@@ -61,13 +58,11 @@ class Dynamic(solver_base):
         self.pyLogger.debug('PyDSS datetime - ' + str(self._Time))
         return self._dssSolution.Converged()
 
-    @track_timing(timer_stats_collector)
     def reSolve(self):
         self._dssSolution.StepSize(0)
         self._dssSolution.SolveNoControl()
         return self._dssSolution.Converged()
 
-    @track_timing(timer_stats_collector)
     def Solve(self):
         self._dssSolution.StepSize(0)
         self._dssSolution.Solve()

--- a/PyDSS/modes/QSTS.py
+++ b/PyDSS/modes/QSTS.py
@@ -25,7 +25,6 @@ class QSTS(solver_base):
         self._dssSolution.DblHour(start_time_hours)
         return
 
-    @track_timing(timer_stats_collector)
     def SolveFor(self, mStartTime, mTimeStep):
         Hour = int(mStartTime/60)
         Min = mStartTime%60
@@ -34,7 +33,6 @@ class QSTS(solver_base):
         self._dssSolution.Solve()
         return self._dssSolution.Converged()
 
-    @track_timing(timer_stats_collector)
     def IncStep(self):
         self._dssSolution.StepSize(self._sStepRes)
         self._dssSolution.Solve()
@@ -43,13 +41,11 @@ class QSTS(solver_base):
         self._Second = (self._dssSolution.DblHour() % 1) * 60 * 60
         return self._dssSolution.Converged()
 
-    @track_timing(timer_stats_collector)
     def reSolve(self):
         self._dssSolution.StepSize(0)
         self._dssSolution.SolveNoControl()
         return self._dssSolution.Converged()
 
-    @track_timing(timer_stats_collector)
     def Solve(self):
         self._dssSolution.StepSize(0)
         self._dssSolution.Solve()

--- a/PyDSS/modes/Snapshot.py
+++ b/PyDSS/modes/Snapshot.py
@@ -1,6 +1,5 @@
 from PyDSS.modes.solver_base import solver_base
 from PyDSS.simulation_input_models import ProjectModel
-from PyDSS.utils.timing_utils import timer_stats_collector, track_timing
 
 
 class Snapshot(solver_base):
@@ -11,7 +10,6 @@ class Snapshot(solver_base):
         self._dssSolution.MaxControlIterations(settings.max_control_iterations)
         return
 
-    @track_timing(timer_stats_collector)
     def reSolve(self):
         self._dssSolution.SolveNoControl()
         return self._dssSolution.Converged()
@@ -19,12 +17,10 @@ class Snapshot(solver_base):
     def SimulationSteps(self):
         return 1, self._StartTime, self._EndTime
 
-    @track_timing(timer_stats_collector)
     def Solve(self):
         self._dssSolution.Solve()
         return self._dssSolution.Converged()
 
-    @track_timing(timer_stats_collector)
     def IncStep(self):
         return self._dssSolution.Solve()
 

--- a/PyDSS/pyControllers/Controllers/PvController.py
+++ b/PyDSS/pyControllers/Controllers/PvController.py
@@ -1,10 +1,8 @@
 from  PyDSS.pyControllers.pyControllerAbstract import ControllerAbstract
 import math
-import abc
 from collections import namedtuple
 
 from PyDSS.pyControllers.pyControllerAbstract import ControllerAbstract
-from PyDSS.utils.timing_utils import timer_stats_collector, track_timing
 
 
 VVarSettings = namedtuple("VVarSettings", ["VmeaMethod", "uMin", "uMax", "uDbMin", "uDbMax", "kVBase"])
@@ -115,7 +113,6 @@ class PvController(ControllerAbstract):
     def debugInfo(self):
         return [self.__Settings['Control{}'.format(i+1)] for i in range(3)]
 
-    @track_timing(timer_stats_collector)
     def Update(self, Priority, Time, Update):
         self.TimeChange = self.Time != (Priority, Time)
         self.Time = (Priority, Time)
@@ -138,7 +135,6 @@ class PvController(ControllerAbstract):
                 return 0
         return self.update[Priority]()
 
-    @track_timing(timer_stats_collector)
     def VWcontrol(self):
         """Volt / Watt  control implementation
         """
@@ -182,7 +178,6 @@ class PvController(ControllerAbstract):
         self.oldPcalc = Ppv
         return Error
 
-    @track_timing(timer_stats_collector)
     def CutoffControl(self):
         """Over voltage trip implementation
         """
@@ -205,7 +200,6 @@ class PvController(ControllerAbstract):
 
         return 0
 
-    @track_timing(timer_stats_collector)
     def CPFcontrol(self):
         """Constant power factor implementation
         """
@@ -234,7 +228,6 @@ class PvController(ControllerAbstract):
         self.__ControlledElm.SetParameter('pf', str(-PFset))
         return Error
 
-    @track_timing(timer_stats_collector)
     def VPFcontrol(self):
         """Variable power factor control implementation
         """
@@ -271,7 +264,6 @@ class PvController(ControllerAbstract):
 
         return 0
 
-    @track_timing(timer_stats_collector)
     def VVARcontrol(self):
         """Volt / var control implementation
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ tables
 h5py
 helics
 terminaltables
-aiohttp
-aiohttp_swagger3==0.4.3
+aiohttp~=3.8.2
+aiohttp_swagger3>=0.4.3
 requests
 pymongo
 pydantic>=1.8


### PR DESCRIPTION
The version requirements for the `aiohttp` libraries were causing errors when installing in a Python 3.11 environment. This PR allows packages with fixes for those problems to get installed. I also noticed that we had some excessive timings stats and removed them.