### PR TITLE
Upgrade pydantic to v2

### DIFF
--- a/PyDSS/controllers.py
+++ b/PyDSS/controllers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional, List, Union
 
 import opendssdirect as dss
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field
 
 from PyDSS.SolveMode import get_solver_from_simulation_type
 from PyDSS.common import SimulationType

--- a/PyDSS/node_voltage_metrics.py
+++ b/PyDSS/node_voltage_metrics.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Union
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from PyDSS.utils.simulation_utils import CircularBufferHelper
 

--- a/PyDSS/pyControllers/Controllers/PvFrequencyRideThru.py
+++ b/PyDSS/pyControllers/Controllers/PvFrequencyRideThru.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 import datetime
 import math
 import os
-from pydantic import BaseModel, validator, conint, confloat
 import pdb
 
 class PvFrequencyRideThru(ControllerAbstract):

--- a/PyDSS/pyControllers/Controllers/PvVoltageRideThru.py
+++ b/PyDSS/pyControllers/Controllers/PvVoltageRideThru.py
@@ -4,7 +4,6 @@ from shapely.ops import triangulate, cascaded_union
 import datetime
 import math
 import os
-from pydantic import BaseModel, validator, conint, confloat
 
 class PvVoltageRideThru(ControllerAbstract):
     """Implementation of IEEE1547-2003 and IEEE1547-2018 voltage ride-through standards using the OpenDSS Generator model. Subclass of the :class:`PyDSS.pyControllers.pyControllerAbstract.ControllerAbstract` abstract class.

--- a/PyDSS/reports/feeder_losses.py
+++ b/PyDSS/reports/feeder_losses.py
@@ -5,7 +5,7 @@ import os
 from datetime import timedelta
 from typing import Dict
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from PyDSS.reports.reports import ReportBase
 

--- a/PyDSS/simulation_input_models.py
+++ b/PyDSS/simulation_input_models.py
@@ -6,8 +6,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, root_validator, validator
-from pydantic.json import isoformat, timedelta_isoformat
+from pydantic.v1 import BaseModel, Field, root_validator, validator
+from pydantic.v1.json import isoformat, timedelta_isoformat
 
 from PyDSS.common import (
     ControlMode,

--- a/PyDSS/thermal_metrics.py
+++ b/PyDSS/thermal_metrics.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Union
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from PyDSS.utils.simulation_utils import CircularBufferHelper
 from PyDSS.utils.utils import dump_data, load_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ aiohttp~=3.8.2
 aiohttp_swagger3>=0.4.3
 requests
 pymongo
-pydantic~=1.10.11
+pydantic~=2.5.2
 matplotlib
 pvder


### PR DESCRIPTION
This allows PyDSS to be compatible with Pydantic v2. Note that it doesn’t actually use the version 2 features; it uses the v1 package within Pydantic. This allows packages that consume PyDSS to use the latest version of Pydantic.