### PR TITLE
Upgrade Pydantic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "OpenDSSDirect.py==0.8.4",
     "pandas~=2.2.3",
     "pvder~=0.6.0",
-    "pydantic~=2.5.3",
+    "pydantic>=2,<3",
     "pymongo~=4.11.3",
     "requests~=2.32.3",
     "scikit-learn~=1.6.1",


### PR DESCRIPTION
The previous version restricted Pydantic to 2.5.x, which fails to build in Python 3.13, at least on macOS.