### PR TITLE
Fix CI workflow branch target and docs KeyError

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -3,7 +3,7 @@ name: Pytests
 on: 
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 

--- a/docs/make_model_tables.py
+++ b/docs/make_model_tables.py
@@ -77,7 +77,7 @@ def make_tables(output):
                 for prop, vals in schema["properties"].items():
                     if vals.get("internal", False):
                         continue
-                    description = format_description(vals["description"])
+                    description = format_description(vals.get("description", ""))
                     title = vals["title"]
                     type_str = property_types.get(name, {}).get(title)
                     if type_str is not None and type_str in all_names:


### PR DESCRIPTION
- Change pull_request_tests.yml to trigger on 'master' instead of 'main'
- Handle missing 'description' key in make_model_tables.py for pydantic 2.10 schema changes